### PR TITLE
feat: Support archive and zip downloads

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
         <v-divider />
         <v-card-text>
           <v-btn class="mr-2" color="primary" @click="toast">Toast</v-btn>
+          <v-btn class="mr-2" color="primary" @click="toastWithLink">Toast with Link</v-btn>
           <v-btn color="primary" @click="openDialog">Open Dialog</v-btn>
         </v-card-text>
       </v-card>
@@ -291,6 +292,7 @@
 
 <script lang="ts">
 import { Component, Vue, toNative, Ref } from 'vue-facing-decorator';
+import { h } from 'vue';
 import CzNotifications from './components/cz.notifications.vue';
 import Notifications from './models/notifications';
 import { Config, IFolder, IFile } from '@/types';
@@ -537,6 +539,19 @@ class App extends Vue {
         // Use in your app to not show the notification again
         console.log(doNotShowAgain);
       },
+    });
+  }
+
+  toastWithLink() {
+    Notifications.toast({
+      title: 'Learn More',
+      message: h('span', [
+        'Learn more in the ',
+        h('a', { href: 'https://github.com/cznethub/cznet-vue-core', target: '_blank', rel: 'noopener noreferrer' }, 'documentation'),
+        '.'
+      ]),
+      type: 'info',
+      location: 'top center',
     });
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,8 +59,11 @@
             :renameFileOrFolder="renameFileOrFolderMock"
             :deleteFileOrFolder="deleteFileOrFolderMock"
             :upload="uploadMock"
+            :showDownloadZippedButton="true"
+            :showDownloadArchiveButton="true"
             @showMetadata="onShowMetadata($event)"
             @download="onFileDownload($event)"
+            @downloadZipped="onDownloadZipped($event)"
             @downloadArchive="onDownloadArchive"
             downloadArchiveHelpText="Download all content as Zipped BagIt Archive"
           >
@@ -552,6 +555,11 @@ class App extends Vue {
   async onFileDownload(items: (IFile | IFolder)[]) {
     console.log(items);
     // Handle file download
+  }
+
+  async onDownloadZipped(items: (IFile | IFolder)[]) {
+    items.forEach(item => console.log(item.path));
+    // Handle zipped file download
   }
 
   async onDownloadArchive() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,8 @@
             :upload="uploadMock"
             @showMetadata="onShowMetadata($event)"
             @download="onFileDownload($event)"
+            @downloadArchive="onDownloadArchive"
+            downloadArchiveHelpText="Download all content as Zipped BagIt Archive"
           >
             <template #prepend>
               <v-alert
@@ -550,6 +552,11 @@ class App extends Vue {
   async onFileDownload(items: (IFile | IFolder)[]) {
     console.log(items);
     // Handle file download
+  }
+
+  async onDownloadArchive() {
+    console.log('downloadArchive');
+    // Handle archive download
   }
 
   async uploadMock(_items: (IFile | IFolder)[]) {

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -16,24 +16,20 @@
         New Folder
       </v-tooltip>
 
-      <div v-else class="text-subtitle-1 mr-4">Files</div>
-
-      <div v-if="!isReadOnly">
-        <template>
-          <v-tooltip bottom transition="fade">
-            <template #activator="{ props }">
-              <v-btn
-                @click="selectAll"
-                :disabled="!rootDirectory.children.length"
-                icon="mdi-select"
-                size="small"
-                variant="text"
-                v-bind="props"
-              ></v-btn>
-            </template>
-            <span>Select All</span>
-          </v-tooltip>
-        </template>
+      <div class="file-action-buttons d-flex align-center flex-wrap gap-1">
+        <v-tooltip bottom transition="fade">
+          <template #activator="{ props }">
+            <v-btn
+              @click="selectAll"
+              :disabled="!rootDirectory.children.length"
+              icon="mdi-select"
+              size="small"
+              variant="text"
+              v-bind="props"
+            ></v-btn>
+          </template>
+          <span>Select All</span>
+        </v-tooltip>
 
         <!-- <template>
           <v-tooltip bottom transition="fade">
@@ -54,7 +50,7 @@
           <v-divider class="mx-4" vertical></v-divider>
         </template> -->
 
-        <template v-if="hasFolders">
+        <template v-if="!isReadOnly && hasFolders">
           <v-tooltip bottom transition="fade">
             <template #activator="{ props }">
               <v-btn
@@ -82,8 +78,9 @@
             </template>
             Paste
           </v-tooltip>
-          <v-divider class="mx-4" vertical></v-divider>
         </template>
+
+        <v-divider class="mx-2" vertical></v-divider>
 
         <template v-if="!isReadOnly">
           <v-tooltip bottom transition="fade">
@@ -102,21 +99,20 @@
           </v-tooltip>
         </template>
 
-        <template v-if="canDownloadSomeSelected">
-          <v-tooltip bottom transition="fade">
-            <template #activator="{ props }">
-              <v-btn
-                @click="onItemsDownload"
-                icon="mdi-download"
-                size="small"
-                variant="text"
-                color="green"
-                v-bind="props"
-              ></v-btn>
-            </template>
-            <span>Download</span>
-          </v-tooltip>
-        </template>
+        <v-tooltip bottom transition="fade">
+          <template #activator="{ props }">
+            <v-btn
+              @click="onItemsDownload"
+              :disabled="!canDownloadSomeSelected"
+              icon="mdi-download"
+              size="small"
+              variant="text"
+              color="green"
+              v-bind="props"
+            ></v-btn>
+          </template>
+          <span>Download</span>
+        </v-tooltip>
       </div>
 
       <v-spacer />
@@ -1799,6 +1795,10 @@ export default toNative(CzFileExplorer);
 <style lang="scss" scoped>
 .border-grey {
   border: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+.file-action-buttons {
+  min-height: 2.5rem;
 }
 
 // `.cz-upload-drop-area` is set as the class on the `<v-file-upload>` root,

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -80,6 +80,21 @@
           </v-tooltip>
         </template>
 
+        <v-tooltip bottom transition="fade">
+          <template #activator="{ props }">
+            <v-btn
+              @click="onDownloadArchive"
+              :disabled="!rootDirectory.children.length"
+              icon="mdi-briefcase-download-outline"
+              size="small"
+              variant="text"
+              color="blue"
+              v-bind="props"
+            ></v-btn>
+          </template>
+          <span>{{ downloadArchiveHelpText }}</span>
+        </v-tooltip>
+
         <v-divider class="mx-2" vertical></v-divider>
 
         <template v-if="!isReadOnly">
@@ -660,7 +675,7 @@ import { FILE_ICONS } from '@/constants';
     VFileUpload,
   },
   directives: { ClickOutside },
-  emits: ['show-metadata', 'update:valid-items', 'download'],
+  emits: ['show-metadata', 'update:valid-items', 'download', 'downloadArchive'],
 })
 class CzFileExplorer extends Vue {
   /** The `IFolder` instance representing the root of the file structure */
@@ -694,6 +709,10 @@ class CzFileExplorer extends Vue {
    * */
   @Prop()
   hasFileMetadata?: (_item: IFile | IFolder) => Promise<boolean>;
+
+  /** Tooltip/help text for the archive download button. */
+  @Prop({ default: 'Download Archive' })
+  downloadArchiveHelpText!: string;
 
   /**
    * Consumer-supplied loader the preview dialog uses to fetch a file's bytes.
@@ -990,6 +1009,10 @@ class CzFileExplorer extends Vue {
       downlodable.forEach(item => (item.path = this.getPathString(item)));
       this.$emit('download', downlodable);
     }
+  }
+
+  onDownloadArchive() {
+    this.$emit('downloadArchive');
   }
 
   onViewDetails(item: IFile | IFolder) {

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -84,7 +84,8 @@
           <template #activator="{ props }">
             <v-btn
               @click="onDownloadZipped"
-              :disabled="!canDownloadZippedSelected"
+              :disabled="!canDownloadZippedSelected || zippedDownloading"
+              :loading="zippedDownloading"
               icon="mdi-download-box-outline"
               size="small"
               variant="text"
@@ -99,7 +100,8 @@
           <template #activator="{ props }">
             <v-btn
               @click="onDownloadArchive"
-              :disabled="!rootDirectory.children.length"
+              :disabled="!rootDirectory.children.length || archiveDownloading"
+              :loading="archiveDownloading"
               icon="mdi-briefcase-download-outline"
               size="small"
               variant="text"
@@ -741,6 +743,12 @@ class CzFileExplorer extends Vue {
   @Prop({ default: 'Download Archive' })
   downloadArchiveHelpText!: string;
 
+  /** If `true`, shows a loading spinner on the archive download button. */
+  @Prop({ default: false }) archiveDownloading!: boolean;
+
+  /** If `true`, shows a loading spinner on the zipped download button. */
+  @Prop({ default: false }) zippedDownloading!: boolean;
+
   /**
    * Consumer-supplied loader the preview dialog uses to fetch a file's bytes.
    * If absent, the Preview menu item is hidden (no point in offering a button
@@ -1047,9 +1055,8 @@ class CzFileExplorer extends Vue {
     const selectedItem = this.selected.length === 1 ? this.selected[0] : null;
 
     if (selectedItem && this.canDownloadItem) {
-      const downlodable = [selectedItem];
-      downlodable.forEach(item => (item.path = this.getPathString(item)));
-      this.$emit('downloadZipped', downlodable);
+      selectedItem.path = this.getPathString(selectedItem);
+      this.$emit('downloadZipped', selectedItem);
     }
   }
 

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -80,7 +80,22 @@
           </v-tooltip>
         </template>
 
-        <v-tooltip bottom transition="fade">
+        <v-tooltip v-if="showDownloadZippedButton" bottom transition="fade">
+          <template #activator="{ props }">
+            <v-btn
+              @click="onDownloadZipped"
+              :disabled="!canDownloadZippedSelected"
+              icon="mdi-download-box-outline"
+              size="small"
+              variant="text"
+              color="blue"
+              v-bind="props"
+            ></v-btn>
+          </template>
+          <span>Download zipped</span>
+        </v-tooltip>
+
+        <v-tooltip v-if="showDownloadArchiveButton" bottom transition="fade">
           <template #activator="{ props }">
             <v-btn
               @click="onDownloadArchive"
@@ -675,7 +690,13 @@ import { FILE_ICONS } from '@/constants';
     VFileUpload,
   },
   directives: { ClickOutside },
-  emits: ['show-metadata', 'update:valid-items', 'download', 'downloadArchive'],
+  emits: [
+    'show-metadata',
+    'update:valid-items',
+    'download',
+    'downloadZipped',
+    'downloadArchive',
+  ],
 })
 class CzFileExplorer extends Vue {
   /** The `IFolder` instance representing the root of the file structure */
@@ -697,6 +718,12 @@ class CzFileExplorer extends Vue {
   @Prop({ default: false }) isReadOnly!: boolean;
   /** Files that passed validation; kept in sync via `v-model:valid-items`. */
   @Prop({ default: () => [] }) validItems!: (IFile | IFolder)[];
+
+  /** If `true`, show the zipped download button. */
+  @Prop({ default: false }) showDownloadZippedButton!: boolean;
+
+  /** If `true`, show the archive download button. */
+  @Prop({ default: false }) showDownloadArchiveButton!: boolean;
 
   /** A function to check if a file or folder can be downloaded using the
    * 'Download' context menu item
@@ -960,6 +987,11 @@ class CzFileExplorer extends Vue {
     return this.selected.some(item => this.canDownloadItem?.(item));
   }
 
+  get canDownloadZippedSelected() {
+    const selectedItem = this.selected.length === 1 ? this.selected[0] : null;
+    return !!selectedItem && this.canDownloadItem?.(selectedItem);
+  }
+
   @Watch('rootDirectory.children', { deep: true })
   protected onInput() {
     const items = this._getDirectoryItems(this.rootDirectory) as (
@@ -1008,6 +1040,16 @@ class CzFileExplorer extends Vue {
       const downlodable = this.selected.filter(this.canDownloadItem);
       downlodable.forEach(item => (item.path = this.getPathString(item)));
       this.$emit('download', downlodable);
+    }
+  }
+
+  onDownloadZipped() {
+    const selectedItem = this.selected.length === 1 ? this.selected[0] : null;
+
+    if (selectedItem && this.canDownloadItem) {
+      const downlodable = [selectedItem];
+      downlodable.forEach(item => (item.path = this.getPathString(item)));
+      this.$emit('downloadZipped', downlodable);
     }
   }
 

--- a/src/components/cz.notifications.vue
+++ b/src/components/cz.notifications.vue
@@ -12,7 +12,8 @@
       <div v-if="snackbar.title" class="text-body-1 pb-4">
         {{ snackbar.title }}
       </div>
-      <p class="text-body-2">{{ snackbar.message }}</p>
+      <p v-if="typeof snackbar.message === 'string'" class="text-body-2">{{ snackbar.message }}</p>
+      <component v-else :is="() => snackbar.message" />
 
       <template #actions>
         <div class="d-flex align-center gap-2">

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { VSnackbar } from 'vuetify/components';
+import type { VNode } from 'vue';
 
 // Vuetify does not export its types, so we unwrap them
 type UnwrapReadonlyArray<A> = A extends Readonly<Array<infer I>> ? I : A;
@@ -7,7 +8,7 @@ export type SnackbarLocation = UnwrapReadonlyArray<VSnackbar['location']>;
 
 export interface IToast {
   title?: string;
-  message: string;
+  message: string | VNode;
   duration?: number;
   location?: SnackbarLocation;
   isInfinite?: boolean;


### PR DESCRIPTION
Adds support for:

- Optional archive download button
- Optional zipped download button
- Including a URL in the toast notification message

Also makes the existing download button available in read-only mode.

Both download buttons emit an event on click that can be listened to by the parent.  There is also a boolean prop for each (`zippedDownloading` and `archiveDownloading`) that can be used to show the button in a loading state (as a spinner).  There is an optional param `downloadArchiveHelpText` which can be used to customize the archive download help text (since this button could be used to download any type of archive -- tarball, bag, etc).

<img width="677" height="536" alt="Screenshot 2026-07-30 at 1 09 48 PM" src="https://github.com/user-attachments/assets/9d2e8091-a02e-433b-8e18-4d6a56948f2b" />


<img width="929" height="220" alt="Screenshot 2026-07-30 at 1 09 28 PM" src="https://github.com/user-attachments/assets/ba661bc1-0734-4cea-97f4-cd6dde4aaa0b" />
