### PR TITLE
Add files button

### DIFF
--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -3,6 +3,18 @@
     <v-sheet
       class="pa-4 d-flex align-center files-container--included flex-wrap gap-1 bg-grey-lighten-4"
     >
+      <v-btn
+        v-if="showAddFiles"
+        @click="onAddFiles"
+        prepend-icon="mdi-file-plus"
+        size="small"
+        variant="elevated"
+        color="primary"
+        class="mr-2"
+      >
+        Add files
+      </v-btn>
+
       <v-tooltip v-if="hasFolders && !isReadOnly" bottom transition="fade">
         <template #activator="{ props }">
           <v-btn
@@ -622,7 +634,7 @@
           mdi-delete-outline
         </v-icon>
       </drop>
-      <template v-else-if="!isReadOnly">
+      <template v-else-if="!isReadOnly && !showAddFiles">
         <slot name="drop-area">
           <v-file-upload
             v-model="dropFiles"
@@ -654,6 +666,7 @@ import { IFolder, IFile } from '@/types';
 import { default as Notifications } from '@/models/notifications';
 // @ts-ignore
 import { DnDEvent, Drag, Drop, DropMask } from 'vue-easy-dnd';
+import { resolveUploadTarget } from '@/utils';
 import CzDragSelect from '@/components/cz.drag-select.vue';
 import CzFileExplorerItem from '@/components/cz.file-explorer-item.vue';
 import CzFilePreview, {
@@ -795,6 +808,10 @@ class CzFileExplorer extends Vue {
    * @returns An boolean array indicating if the file was uploaded successfully
    */
   @Prop() upload?: (_items: IFile[] | IFolder[]) => Promise<boolean[]>;
+
+  /** Opens the consumer's upload UI, targeted at `_folder`. When provided, the
+   * toolbar shows an 'Add files' button and the inline drop area is hidden. */
+  @Prop() addFiles?: (_folder: IFolder, _path: string) => void;
 
   fileIcons = FILE_ICONS;
   breakpoints: any = useDisplay();
@@ -991,6 +1008,14 @@ class CzFileExplorer extends Vue {
     } else {
       return this.selected[0] || this.rootDirectory;
     }
+  }
+
+  get addFilesTarget(): IFolder {
+    return resolveUploadTarget(this.rootDirectory, this.selected);
+  }
+
+  get showAddFiles(): boolean {
+    return !this.isReadOnly && !!this.addFiles;
   }
 
   get canPaste() {
@@ -1303,6 +1328,11 @@ class CzFileExplorer extends Vue {
 
   selectAll() {
     this.select(this.allItems);
+  }
+
+  onAddFiles() {
+    const folder = this.addFilesTarget;
+    this.addFiles?.(folder, this.getPathString(folder));
   }
 
   getParent(item: IFile | IFolder): IFolder {

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -161,7 +161,9 @@
 
       <v-spacer />
 
-      <template v-if="rootDirectory.children.length && !isReadOnly">
+      <template
+        v-if="showDiscardAll && rootDirectory.children.length && !isReadOnly"
+      >
         <v-spacer></v-spacer>
         <v-btn
           @click="discardAll"
@@ -344,7 +346,13 @@
         />
         <div
           class="files-container"
-          :class="isRootDragging && isDragMoving ? 'border-dash' : ''"
+          :class="{
+            'border-dash':
+              (isRootDragging && isDragMoving) || !!nativeDropTarget,
+          }"
+          @dragover="onNativeDragOver($event)"
+          @dragleave="onNativeDragLeave($event)"
+          @drop="onNativeDrop($event)"
         >
           <drop
             @drop="onDropMove($event, rootDirectory)"
@@ -420,6 +428,12 @@
                             v-else
                             @click.right.exact.prevent="show($event, item)"
                             @retry-upload="retryUpload(item)"
+                            @dragover="onNativeDragOver($event, item)"
+                            @dragleave="onNativeDragLeave($event)"
+                            @drop="onNativeDrop($event, item)"
+                            :class="{
+                              'native-drop-target': isNativeDropTarget(item),
+                            }"
                             :item="item"
                             :isOpen="opened.includes(item)"
                             :folderColor="folderColor"
@@ -666,7 +680,11 @@ import { IFolder, IFile } from '@/types';
 import { default as Notifications } from '@/models/notifications';
 // @ts-ignore
 import { DnDEvent, Drag, Drop, DropMask } from 'vue-easy-dnd';
-import { resolveUploadTarget } from '@/utils';
+import {
+  extractDroppedFiles,
+  resolveDropTarget,
+  resolveUploadTarget,
+} from '@/utils';
 import CzDragSelect from '@/components/cz.drag-select.vue';
 import CzFileExplorerItem from '@/components/cz.file-explorer-item.vue';
 import CzFilePreview, {
@@ -749,6 +767,8 @@ class CzFileExplorer extends Vue {
   @Prop({ default: false }) hasFolders!: boolean;
   /** If `true`, render the file browser in read-only state. Files and folders cannot be edited. */
   @Prop({ default: false }) isReadOnly!: boolean;
+  /** Set `false` when uploads happen immediately rather than being staged. */
+  @Prop({ default: true }) showDiscardAll!: boolean;
   /** Files that passed validation; kept in sync via `v-model:valid-items`. */
   @Prop({ default: () => [] }) validItems!: (IFile | IFolder)[];
 
@@ -835,6 +855,8 @@ class CzFileExplorer extends Vue {
   keyCounter = 0;
   ignoreNextClick = false;
   isDragMoving = false;
+  /** Folder a native file drag is currently hovering, or null when not over one. */
+  nativeDropTarget: IFolder | null = null;
   isRootDragging = false;
   prettyBytes = prettyBytes;
 
@@ -1243,16 +1265,15 @@ class CzFileExplorer extends Vue {
   async onFilesDropped(
     newFiles: File[],
     _oldFiles: File[],
-    nameOverrides?: { [index: string]: string }
+    nameOverrides?: { [index: string]: string },
+    targetOverride?: IFolder
   ) {
     if (!newFiles.length) {
       return;
     }
-    const targetFolder: IFolder = this.activeDirectoryItem.hasOwnProperty(
-      'children'
-    )
-      ? (this.activeDirectoryItem as IFolder)
-      : this.getParent(this.activeDirectoryItem);
+    const targetFolder: IFolder =
+      targetOverride ??
+      resolveUploadTarget(this.rootDirectory, this.selected);
 
     const addedFiles = newFiles.map((file, index) => {
       const newItem = {
@@ -1333,6 +1354,52 @@ class CzFileExplorer extends Vue {
   onAddFiles() {
     const folder = this.addFilesTarget;
     this.addFiles?.(folder, this.getPathString(folder));
+  }
+
+  /** True while the pointer carries files from outside the page. */
+  private _isFileDrag(event: DragEvent): boolean {
+    return !!event.dataTransfer?.types?.includes('Files');
+  }
+
+  onNativeDragOver(event: DragEvent, item?: IFile | IFolder) {
+    if (this.isReadOnly || !this._isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+    this.nativeDropTarget = resolveDropTarget(this.rootDirectory, item);
+  }
+
+  onNativeDragLeave(event: DragEvent) {
+    const to = event.relatedTarget as Node | null;
+    if (to && (event.currentTarget as Node)?.contains(to)) {
+      return;
+    }
+    this.nativeDropTarget = null;
+  }
+
+  async onNativeDrop(event: DragEvent, item?: IFile | IFolder) {
+    if (this.isReadOnly || !this._isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+
+    const files = extractDroppedFiles(event.dataTransfer);
+    const targetFolder = resolveDropTarget(this.rootDirectory, item);
+    this.nativeDropTarget = null;
+
+    if (files.length) {
+      await this.onFilesDropped(files, [], undefined, targetFolder);
+    }
+  }
+
+  /** Only the folder row itself lights up; a file's target shows on the container. */
+  isNativeDropTarget(item: IFile | IFolder): boolean {
+    return !!this.nativeDropTarget && this.nativeDropTarget === item;
   }
 
   getParent(item: IFile | IFolder): IFolder {
@@ -2020,13 +2087,21 @@ export default toNative(CzFileExplorer);
   height: 15rem;
   overflow: auto;
   resize: vertical;
+  // Always present so showing the drop highlight does not reflow the page.
+  border: 1px dashed transparent;
 
-  // Highlight the drop target while a drag is in flight. The previous markup
-  // wrapped this region in a v-card; now the dashed border lives directly on
-  // the scrollable file-tree container.
   &.border-dash {
-    border: 1px dashed rgba(0, 0, 0, 0.4) !important;
+    border-color: rgba(0, 0, 0, 0.4) !important;
   }
+}
+
+// The folder row a native file drag is hovering. Outline rather than border so
+// it takes no layout space; inset so it is not clipped by the scroll container.
+.native-drop-target {
+  border-radius: 4px;
+  outline: 1px solid rgb(var(--v-theme-primary));
+  outline-offset: -1px;
+  background-color: rgba(var(--v-theme-primary), 0.08);
 }
 
 .cz-drag-select {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,19 @@ export function findParentFolder(
   return searchParent(root, item) || root;
 }
 
+/** The folder an item stands for as a drop target: itself, or its parent when it is a file. */
+export function resolveDropTarget(
+  root: IFolder,
+  item: IFile | IFolder | null | undefined
+): IFolder {
+  if (!item) {
+    return root;
+  }
+  return isFolderItem(item)
+    ? (item as IFolder)
+    : findParentFolder(root, item);
+}
+
 /**
  * Where an upload should land: the selected folder, a selected file's parent,
  * or the root when the selection is empty or ambiguous.
@@ -58,7 +71,26 @@ export function resolveUploadTarget(
   selected: (IFile | IFolder)[]
 ): IFolder {
   const active = selected.length === 1 && selected[0] ? selected[0] : root;
-  return isFolderItem(active)
-    ? (active as IFolder)
-    : findParentFolder(root, active);
+  return resolveDropTarget(root, active);
+}
+
+/** Files from a native drop, skipping any directory entries. */
+export function extractDroppedFiles(dataTransfer: DataTransfer | null): File[] {
+  if (!dataTransfer) {
+    return [];
+  }
+
+  const items = Array.from(dataTransfer.items || []);
+  if (!items.length) {
+    return Array.from(dataTransfer.files || []);
+  }
+
+  return items
+    .filter(item => item.kind === 'file')
+    .filter(item => {
+      const entry = (item as any).webkitGetAsEntry?.();
+      return !entry || entry.isFile;
+    })
+    .map(item => item.getAsFile())
+    .filter((file): file is File => !!file);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { IFile, IFolder } from '@/types';
+
 /** Stringify a JSON object and avoid circular references */
 export function stringify(obj: any) {
   let cache: any = [];
@@ -14,4 +16,49 @@ export function stringify(obj: any) {
   });
   cache = null; // reset the cache
   return str;
+}
+
+/** An item is a folder when it carries a `children` array. */
+export function isFolderItem(item: IFile | IFolder): boolean {
+  return !!item && Object.prototype.hasOwnProperty.call(item, 'children');
+}
+
+function searchParent(folder: IFolder, item: IFile | IFolder): IFolder | null {
+  if (folder.children?.includes(item)) {
+    return folder;
+  }
+
+  for (const child of folder.children || []) {
+    if (!isFolderItem(child)) {
+      continue;
+    }
+    const found = searchParent(child as IFolder, item);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+/** The folder containing `item`, or `root` when it has no parent in the tree. */
+export function findParentFolder(
+  root: IFolder,
+  item: IFile | IFolder
+): IFolder {
+  return searchParent(root, item) || root;
+}
+
+/**
+ * Where an upload should land: the selected folder, a selected file's parent,
+ * or the root when the selection is empty or ambiguous.
+ */
+export function resolveUploadTarget(
+  root: IFolder,
+  selected: (IFile | IFolder)[]
+): IFolder {
+  const active = selected.length === 1 && selected[0] ? selected[0] : root;
+  return isFolderItem(active)
+    ? (active as IFolder)
+    : findParentFolder(root, active);
 }

--- a/test/dropped-files.test.ts
+++ b/test/dropped-files.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { IFile, IFolder } from '@/types';
+import { extractDroppedFiles, resolveDropTarget } from '@/utils';
+
+const file = (name: string): IFile => ({ name, file: null } as unknown as IFile);
+const folder = (name: string, children: (IFile | IFolder)[] = []): IFolder =>
+  ({ name, children } as unknown as IFolder);
+
+function tree() {
+  const buried = file('buried.txt');
+  const deep = folder('deep', [buried]);
+  const nested = file('nested.txt');
+  const docs = folder('docs', [nested, deep]);
+  const top = file('top.txt');
+  const root = folder('', [top, docs]);
+  return { root, docs, deep, top, nested, buried };
+}
+
+describe('resolveDropTarget', () => {
+  it('drops into the folder itself', () => {
+    const { root, docs } = tree();
+    expect(resolveDropTarget(root, docs)).toBe(docs);
+  });
+
+  it('drops into a nested folder', () => {
+    const { root, deep } = tree();
+    expect(resolveDropTarget(root, deep)).toBe(deep);
+  });
+
+  it("drops beside a file, into that file's parent", () => {
+    const { root, docs, nested } = tree();
+    expect(resolveDropTarget(root, nested)).toBe(docs);
+  });
+
+  it('drops a top-level file into root', () => {
+    const { root, top } = tree();
+    expect(resolveDropTarget(root, top)).toBe(root);
+  });
+
+  it('drops into root when there is no item under the cursor', () => {
+    const { root } = tree();
+    expect(resolveDropTarget(root, null)).toBe(root);
+    expect(resolveDropTarget(root, undefined)).toBe(root);
+  });
+});
+
+const asFile = (name: string) => new File(['x'], name);
+
+/** Minimal stand-in for the DataTransfer a browser hands to a drop handler. */
+function dataTransfer(
+  items: { kind: string; file?: File; entry?: { isFile: boolean } | null }[],
+  files: File[] = [],
+): DataTransfer {
+  return {
+    items: items.map(i => ({
+      kind: i.kind,
+      getAsFile: () => i.file ?? null,
+      webkitGetAsEntry: () => (i.entry === undefined ? { isFile: true } : i.entry),
+    })),
+    files,
+  } as unknown as DataTransfer;
+}
+
+describe('extractDroppedFiles', () => {
+  it('returns nothing when there is no data transfer', () => {
+    expect(extractDroppedFiles(null)).toEqual([]);
+  });
+
+  it('returns the dropped files', () => {
+    const a = asFile('a.txt');
+    const b = asFile('b.txt');
+    const result = extractDroppedFiles(
+      dataTransfer([
+        { kind: 'file', file: a },
+        { kind: 'file', file: b },
+      ]),
+    );
+    expect(result).toEqual([a, b]);
+  });
+
+  it('skips directory entries', () => {
+    const loose = asFile('loose.txt');
+    const dir = asFile('a-folder');
+    const result = extractDroppedFiles(
+      dataTransfer([
+        { kind: 'file', file: loose },
+        { kind: 'file', file: dir, entry: { isFile: false } },
+      ]),
+    );
+    expect(result).toEqual([loose]);
+  });
+
+  it('skips non-file items such as dragged text', () => {
+    const a = asFile('a.txt');
+    const result = extractDroppedFiles(
+      dataTransfer([
+        { kind: 'string', file: null as unknown as File },
+        { kind: 'file', file: a },
+      ]),
+    );
+    expect(result).toEqual([a]);
+  });
+
+  it('drops items whose getAsFile returns null', () => {
+    const a = asFile('a.txt');
+    const result = extractDroppedFiles(
+      dataTransfer([
+        { kind: 'file', file: undefined },
+        { kind: 'file', file: a },
+      ]),
+    );
+    expect(result).toEqual([a]);
+  });
+
+  it('keeps files when the browser gives no entry information', () => {
+    const a = asFile('a.txt');
+    const result = extractDroppedFiles(
+      dataTransfer([{ kind: 'file', file: a, entry: null }]),
+    );
+    expect(result).toEqual([a]);
+  });
+
+  it('falls back to the files list when items is empty', () => {
+    const a = asFile('a.txt');
+    expect(extractDroppedFiles(dataTransfer([], [a]))).toEqual([a]);
+  });
+});

--- a/test/upload-target.test.ts
+++ b/test/upload-target.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { IFile, IFolder } from '@/types';
+import {
+  findParentFolder,
+  isFolderItem,
+  resolveUploadTarget,
+} from '@/utils';
+
+const file = (name: string): IFile => ({ name, file: null } as unknown as IFile);
+const folder = (name: string, children: (IFile | IFolder)[] = []): IFolder =>
+  ({ name, children } as unknown as IFolder);
+
+/**
+ *  root
+ *  ├── top.txt
+ *  └── docs
+ *      ├── nested.txt
+ *      └── deep
+ *          └── buried.txt
+ */
+function tree() {
+  const buried = file('buried.txt');
+  const deep = folder('deep', [buried]);
+  const nested = file('nested.txt');
+  const docs = folder('docs', [nested, deep]);
+  const top = file('top.txt');
+  const root = folder('', [top, docs]);
+  return { root, docs, deep, top, nested, buried };
+}
+
+describe('isFolderItem', () => {
+  it('distinguishes folders from files by the children property', () => {
+    expect(isFolderItem(folder('docs'))).toBe(true);
+    expect(isFolderItem(file('a.txt'))).toBe(false);
+  });
+});
+
+describe('findParentFolder', () => {
+  it('returns root for a top-level item', () => {
+    const { root, top } = tree();
+    expect(findParentFolder(root, top)).toBe(root);
+  });
+
+  it('finds the immediate parent of a nested file', () => {
+    const { root, docs, nested } = tree();
+    expect(findParentFolder(root, nested)).toBe(docs);
+  });
+
+  it('finds the parent of a deeply nested file', () => {
+    const { root, deep, buried } = tree();
+    expect(findParentFolder(root, buried)).toBe(deep);
+  });
+
+  it('finds the parent of a nested folder', () => {
+    const { root, docs, deep } = tree();
+    expect(findParentFolder(root, deep)).toBe(docs);
+  });
+
+  it('falls back to root for an item that is not in the tree', () => {
+    const { root } = tree();
+    expect(findParentFolder(root, file('orphan.txt'))).toBe(root);
+  });
+});
+
+describe('resolveUploadTarget', () => {
+  it('uploads to root when nothing is selected', () => {
+    const { root } = tree();
+    expect(resolveUploadTarget(root, [])).toBe(root);
+  });
+
+  it('uploads into the selected folder', () => {
+    const { root, docs } = tree();
+    expect(resolveUploadTarget(root, [docs])).toBe(docs);
+  });
+
+  it('uploads into a deeply selected folder', () => {
+    const { root, deep } = tree();
+    expect(resolveUploadTarget(root, [deep])).toBe(deep);
+  });
+
+  it("uploads beside a selected file, into that file's parent", () => {
+    const { root, docs, nested } = tree();
+    expect(resolveUploadTarget(root, [nested])).toBe(docs);
+  });
+
+  it('uploads to root when the selected file is top-level', () => {
+    const { root, top } = tree();
+    expect(resolveUploadTarget(root, [top])).toBe(root);
+  });
+
+  it('falls back to root when the selection is ambiguous', () => {
+    const { root, docs, deep } = tree();
+    expect(resolveUploadTarget(root, [docs, deep])).toBe(root);
+  });
+
+  it('falls back to root when the single selection is nullish', () => {
+    const { root } = tree();
+    expect(resolveUploadTarget(root, [undefined as unknown as IFile])).toBe(root);
+  });
+});


### PR DESCRIPTION
Adds the file explorer pieces needed for https://github.com/hydroshare/hydroshare/issues/6436.

- New optional `addFiles` callback prop. When provided, the toolbar shows an
  "Add files" button and the inline drop area is hidden, so the consumer
  supplies its own upload UI. Consumers that omit it are unchanged.
- Files can be dragged onto the browser itself. Drop position decides the
  target: onto a folder goes into that folder, onto a file goes into its
  parent, anywhere else goes to the root. The hovered folder is highlighted.
- New `showDiscardAll` prop (default `true`) so consumers that upload
  immediately, rather than staging, can hide the Discard All button.