### PR TITLE
Other file explorer improvements

### DIFF
--- a/src/components/cz.file-explorer.selection.ts
+++ b/src/components/cz.file-explorer.selection.ts
@@ -1,0 +1,121 @@
+import { toRaw } from 'vue';
+import type { ActiveStrategy } from 'vuetify';
+import type { IFile, IFolder } from '@/types';
+
+/** The file explorer state the selection strategy operates on. */
+export interface SelectionContext {
+  getParent(item: IFile | IFolder): IFolder;
+  isFolder(item: IFile | IFolder): boolean;
+  open(items: (IFile | IFolder)[]): void;
+  getShiftAnchor(): IFile | IFolder | null;
+  setShiftAnchor(item: IFile | IFolder | null): void;
+}
+
+/**
+ * Custom `v-treeview` active strategy implementing file-explorer selection:
+ * plain click selects one item, ctrl/cmd click toggles, shift click selects
+ * the range between the shift anchor and the clicked item.
+ *
+ * Vuetify keeps raw (non-reactive) objects in the activated set, so every
+ * comparison and every item added here must go through `toRaw`: the tree
+ * arrays hold reactive proxies, and a raw item never matches its proxy.
+ */
+export function createFileExplorerActiveStrategy(
+  ctx: SelectionContext
+): ActiveStrategy {
+  const onItemClick = (
+    item: IFolder | IFile,
+    activated: Set<IFile | IFolder>
+  ) => {
+    activated.clear();
+    activated.add(item);
+    if (ctx.isFolder(item)) {
+      ctx.open([item]);
+    }
+    ctx.setShiftAnchor(item);
+  };
+
+  const onItemCtrlClick = (
+    item: IFolder | IFile,
+    activated: Set<IFile | IFolder>
+  ) => {
+    if (activated.has(item)) {
+      activated.delete(item);
+    } else {
+      activated.add(item);
+    }
+    ctx.setShiftAnchor(item);
+  };
+
+  const onItemShiftClick = (
+    item: IFolder | IFile,
+    activated: Set<IFile | IFolder>
+  ) => {
+    if (!ctx.getShiftAnchor()) {
+      ctx.setShiftAnchor(item);
+    }
+    const children = ctx
+      .getParent(item)
+      .children.map(child => toRaw(child) as IFile | IFolder);
+    const anchor = toRaw(ctx.getShiftAnchor()) as IFile | IFolder;
+    const itemIndex = Math.max(0, children.indexOf(item));
+    const anchorIndex = Math.max(0, children.indexOf(anchor));
+
+    activated.clear();
+
+    const first = Math.min(itemIndex, anchorIndex);
+    const last = Math.max(itemIndex, anchorIndex);
+
+    for (let i = first; i <= last; i++) {
+      activated.add(children[i]);
+    }
+  };
+
+  const strategy: ActiveStrategy = {
+    // @ts-ignore
+    activate: ({ id, value, activated, children, parents, event }) => {
+      id = toRaw(id);
+
+      if (!event && activated.has(id)) return activated;
+
+      const item = id as IFile | IFolder;
+      const activatedItems = activated as Set<IFile | IFolder>;
+
+      // @ts-ignore
+      if (event?.ctrlKey || event?.metaKey) {
+        onItemCtrlClick(item, activatedItems);
+        // @ts-ignore
+      } else if (event?.shiftKey) {
+        onItemShiftClick(item, activatedItems);
+      } else {
+        onItemClick(item, activatedItems);
+      }
+
+      return activated;
+    },
+    in: (v: any, children: any, parents: any) => {
+      let set: Set<IFile | IFolder> = new Set(v.map((i: any) => toRaw(i)));
+
+      if (v != null) {
+        for (const id of v) {
+          const activated = strategy.activate({
+            id,
+            value: true,
+            activated: new Set(set),
+            children,
+            parents,
+            event: undefined,
+          });
+
+          set = new Set([...set, ...activated]) as Set<IFile | IFolder>;
+        }
+      }
+      return set;
+    },
+    out: (v: any) => {
+      return Array.from(v);
+    },
+  };
+
+  return strategy;
+}

--- a/src/components/cz.file-explorer.tree.ts
+++ b/src/components/cz.file-explorer.tree.ts
@@ -1,0 +1,54 @@
+import { toRaw } from 'vue';
+import type { IFile, IFolder } from '@/types';
+
+function isFolder(item: IFile | IFolder): item is IFolder {
+  return Object.prototype.hasOwnProperty.call(item, 'children');
+}
+
+/** Maps every node in the forest (as a raw object) to its path string. */
+export function collectPaths(
+  children: (IFile | IFolder)[],
+  prefix = '',
+  out = new Map<IFile | IFolder, string>()
+): Map<IFile | IFolder, string> {
+  for (const child of children || []) {
+    const raw = toRaw(child) as IFile | IFolder;
+    const path = prefix ? `${prefix}/${raw.name}` : raw.name;
+    out.set(raw, path);
+    if (isFolder(raw)) {
+      collectPaths(raw.children, path, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolves items that referenced nodes of `oldChildren` to their equivalents
+ * in `newChildren`, matching by path. Items still present in the new forest
+ * are kept as-is; items whose path no longer exists are dropped.
+ *
+ * Used when a consumer replaces the file tree wholesale (e.g. re-reading it
+ * from the server after a move): state like the opened folders and the
+ * selection would otherwise point at dead objects and reset.
+ */
+export function resolveAcrossForests(
+  items: (IFile | IFolder)[],
+  oldChildren: (IFile | IFolder)[],
+  newChildren: (IFile | IFolder)[]
+): (IFile | IFolder)[] {
+  const oldPaths = collectPaths(oldChildren);
+  const newPaths = collectPaths(newChildren);
+  const newByPath = new Map<string, IFile | IFolder>();
+  for (const [node, path] of newPaths) {
+    newByPath.set(path, node);
+  }
+
+  return items
+    .map(item => {
+      const raw = toRaw(item) as IFile | IFolder;
+      if (newPaths.has(raw)) return raw;
+      const path = oldPaths.get(raw);
+      return path !== undefined ? (newByPath.get(path) ?? null) : null;
+    })
+    .filter((item): item is IFile | IFolder => item !== null);
+}

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -656,6 +656,7 @@ import { default as Notifications } from '@/models/notifications';
 import { DnDEvent, Drag, Drop, DropMask } from 'vue-easy-dnd';
 import CzDragSelect from '@/components/cz.drag-select.vue';
 import CzFileExplorerItem from '@/components/cz.file-explorer-item.vue';
+import { createFileExplorerActiveStrategy } from '@/components/cz.file-explorer.selection';
 import CzFilePreview, {
   PreviewRenderer,
 } from '@/components/cz.file-preview.vue';
@@ -821,103 +822,15 @@ class CzFileExplorer extends Vue {
   isRootDragging = false;
   prettyBytes = prettyBytes;
 
-  customActiveStrategy = (_mandatory?: boolean): ActiveStrategy => {
-    const onItemClick = (
-      item: IFolder | IFile,
-      activated: Set<IFile | IFolder>
-    ) => {
-      activated.clear();
-      activated.add(item);
-      if (this.isFolder(item)) {
-        this.open([item]);
-      }
-      this.shiftAnchor = item;
-    };
-
-    const onItemCtrlClick = (
-      item: IFolder | IFile,
-      activated: Set<IFile | IFolder>
-    ) => {
-      if (activated.has(item)) {
-        activated.delete(item);
-      } else {
-        activated.add(item);
-      }
-      this.shiftAnchor = item;
-    };
-
-    const onItemShiftClick = (
-      item: IFolder | IFile,
-      activated: Set<IFile | IFolder>
-    ) => {
-      const parent = this.getParent(item);
-      const itemIndex = parent.children.indexOf(item);
-      const anchorIndex = this.shiftAnchor
-        ? Math.max(0, parent.children.indexOf(this.shiftAnchor))
-        : 0;
-
-      activated.clear();
-
-      const first = Math.min(itemIndex, anchorIndex);
-      const last = Math.max(itemIndex, anchorIndex);
-
-      for (let i = first; i <= last; i++) {
-        activated.add(parent.children[i]);
-      }
-    };
-
-    const strategy: ActiveStrategy = {
-      // @ts-ignore
-      activate: ({ id, value, activated, children, parents, event }) => {
-        id = toRaw(id);
-
-        if (!event && activated.has(id)) return activated;
-
-        // @ts-ignore
-        event?.ctrlKey
-          ? onItemCtrlClick(
-              id as IFile | IFolder,
-              activated as Set<IFile | IFolder>
-            )
-          : // @ts-ignore
-            event?.shiftKey
-            ? onItemShiftClick(
-                id as IFile | IFolder,
-                activated as Set<IFile | IFolder>
-              )
-            : onItemClick(
-                id as IFile | IFolder,
-                activated as Set<IFile | IFolder>
-              );
-
-        return activated;
-      },
-      in: (v: any, children: any, parents: any) => {
-        let set: Set<IFile | IFolder> = new Set(v.map((i: any) => toRaw(i)));
-
-        if (v != null) {
-          for (const id of v) {
-            const activated = strategy.activate({
-              id,
-              value: true,
-              activated: new Set(set),
-              children,
-              parents,
-              event: undefined,
-            });
-
-            set = new Set([...set, ...activated]) as Set<IFile | IFolder>;
-          }
-        }
-        return set;
-      },
-      out: (v: any) => {
-        return Array.from(v);
-      },
-    };
-
-    return strategy;
-  };
+  customActiveStrategy(_mandatory?: boolean): ActiveStrategy {
+    return createFileExplorerActiveStrategy({
+      getParent: item => this.getParent(item),
+      isFolder: item => this.isFolder(item),
+      open: items => this.open(items),
+      getShiftAnchor: () => this.shiftAnchor,
+      setShiftAnchor: item => (this.shiftAnchor = item),
+    });
+  }
 
   menuAttrs: Record<any, any> = {
     // 'position-x': 0,
@@ -1306,9 +1219,13 @@ class CzFileExplorer extends Vue {
   }
 
   getParent(item: IFile | IFolder): IFolder {
+    // Compare raw objects: callers may hold the raw item while the tree
+    // holds reactive proxies (or vice versa).
+    const target = toRaw(item);
     return (
-      this.allFolders.find(folder => folder.children?.includes(item)) ||
-      this.rootDirectory
+      this.allFolders.find(folder =>
+        folder.children?.some(child => toRaw(child) === target)
+      ) || this.rootDirectory
     );
   }
 

--- a/src/components/cz.file-explorer.vue
+++ b/src/components/cz.file-explorer.vue
@@ -384,7 +384,6 @@
                           :data="item"
                           @dragstart="onDragStart"
                           @dragend="isDragMoving = false"
-                          drag-class="drag-ghost"
                           go-back
                           :class="{ highlight: item.highlight }"
                         >
@@ -492,6 +491,20 @@
                               </v-menu>
                             </template>
                           </cz-file-explorer-item>
+
+                          <template #drag-image>
+                            <div class="drag-chip">
+                              <v-icon
+                                size="18"
+                                :color="isFolder(item) ? folderColor : fileColor"
+                              >
+                                {{ dragGhostIcon(item) }}
+                              </v-icon>
+                              <span class="drag-chip-label">
+                                {{ dragGhostLabel(item) }}
+                              </span>
+                            </div>
+                          </template>
                         </drag>
                       </drop>
                     </template>
@@ -657,6 +670,7 @@ import { DnDEvent, Drag, Drop, DropMask } from 'vue-easy-dnd';
 import CzDragSelect from '@/components/cz.drag-select.vue';
 import CzFileExplorerItem from '@/components/cz.file-explorer-item.vue';
 import { createFileExplorerActiveStrategy } from '@/components/cz.file-explorer.selection';
+import { resolveAcrossForests } from '@/components/cz.file-explorer.tree';
 import CzFilePreview, {
   PreviewRenderer,
 } from '@/components/cz.file-preview.vue';
@@ -933,13 +947,43 @@ class CzFileExplorer extends Vue {
   }
 
   @Watch('rootDirectory.children', { deep: true })
-  protected onInput() {
+  protected onInput(
+    newChildren?: (IFile | IFolder)[],
+    oldChildren?: (IFile | IFolder)[]
+  ) {
+    if (oldChildren && newChildren && newChildren !== oldChildren) {
+      this._onTreeReplaced(oldChildren);
+    }
     const items = this._getDirectoryItems(this.rootDirectory) as (
       | IFile
       | IFolder
     )[];
     const validItems = items.filter(item => !this.isFileInvalid(item as IFile));
     this.$emit('update:valid-items', validItems);
+  }
+
+  /**
+   * When a consumer replaces the tree wholesale (e.g. re-reading it from the
+   * server after a move), the opened folders and the selection would point at
+   * dead objects and every folder would collapse. Carry that state over to
+   * the new tree by path.
+   */
+  private _onTreeReplaced(oldChildren: (IFile | IFolder)[]) {
+    this._annotateDirectory(this.rootDirectory);
+    const newChildren = this.rootDirectory.children;
+    this.opened = resolveAcrossForests(this.opened, oldChildren, newChildren);
+    this.selected = resolveAcrossForests(
+      this.selected,
+      oldChildren,
+      newChildren
+    );
+    this.shiftAnchor = this.shiftAnchor
+      ? (resolveAcrossForests(
+          [this.shiftAnchor],
+          oldChildren,
+          newChildren
+        )[0] ?? null)
+      : null;
   }
 
   getItemById(id: number) {
@@ -1259,6 +1303,21 @@ class CzFileExplorer extends Vue {
 
   isSelected(item: IFolder | IFile) {
     return this.selected.includes(item);
+  }
+
+  dragGhostIcon(item: IFolder | IFile): string {
+    if (this.isFolder(item)) {
+      return 'mdi-folder';
+    }
+    return (
+      this.fileIcons[item.name.split('.').pop() || ''] ||
+      this.fileIcons['default']
+    );
+  }
+
+  dragGhostLabel(item: IFolder | IFile): string {
+    const count = this.selectedItems.length;
+    return this.isSelected(item) && count > 1 ? `${count} items` : item.name;
   }
 
   select(items: (IFolder | IFile)[]) {
@@ -1920,10 +1979,31 @@ export default toNative(CzFileExplorer);
   min-height: 100%;
 }
 
-.drag-ghost {
-  background: white !important;
-  border: 1px solid #ddd !important;
-  height: 3rem !important;
+// Offscreen host for the #drag-image slot; its hiding rule lives in
+// vue-easy-dnd's dnd.css, which we don't load.
+:deep(.__drag-image) {
+  position: fixed;
+  top: -10000px;
+  left: -10000px;
+}
+
+.drag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  max-width: 16rem;
+  padding: 0.3rem 0.8rem;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
+  font-size: 0.875rem;
+
+  .drag-chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 // Make the item content span the full row so controls (drag handle, context

--- a/test/file-explorer-selection.test.ts
+++ b/test/file-explorer-selection.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import { reactive, toRaw } from 'vue';
+import {
+  createFileExplorerActiveStrategy,
+  SelectionContext,
+} from '../src/components/cz.file-explorer.selection';
+import { IFile, IFolder } from '../src/types';
+
+let keyCounter = 0;
+
+function file(name: string): IFile {
+  return { name, key: keyCounter++, file: null, isUploaded: true };
+}
+
+function folder(name: string, children: (IFile | IFolder)[] = []): IFolder {
+  return { name, key: keyCounter++, children };
+}
+
+function isFolder(item: IFile | IFolder): boolean {
+  return Object.prototype.hasOwnProperty.call(item, 'children');
+}
+
+/**
+ * Test double mirroring how CzFileExplorer provides the context: the tree and
+ * the anchor live in reactive state (so reads return proxies), while vuetify
+ * hands the strategy raw items.
+ */
+function makeContext(root: IFolder) {
+  const state = reactive({ root, anchor: null as IFile | IFolder | null });
+  const opened: string[] = [];
+
+  const allFolders = (dir: IFolder): IFolder[] => {
+    const folders = dir.children.filter(isFolder) as IFolder[];
+    return [...folders, ...folders.flatMap(allFolders)];
+  };
+
+  const ctx: SelectionContext = {
+    getParent: item => {
+      const target = toRaw(item);
+      return (
+        allFolders(state.root).find(f =>
+          f.children?.some(child => toRaw(child) === target)
+        ) || state.root
+      );
+    },
+    isFolder,
+    open: items => opened.push(...items.map(i => i.name)),
+    getShiftAnchor: () => state.anchor,
+    setShiftAnchor: item => (state.anchor = item),
+  };
+
+  return { ctx, state, opened };
+}
+
+function activate(
+  strategy: any,
+  id: IFile | IFolder,
+  event: Partial<MouseEvent> | undefined,
+  activated: Set<IFile | IFolder> = new Set()
+): Set<IFile | IFolder> {
+  return strategy.activate({
+    id,
+    value: true,
+    activated,
+    children: new Map(),
+    parents: new Map(),
+    event,
+  });
+}
+
+function names(set: Set<IFile | IFolder>): string[] {
+  return [...set].map(i => i && i.name);
+}
+
+describe('createFileExplorerActiveStrategy', () => {
+  // Mirrors the playground/landing-page structure: a folder with files,
+  // an empty folder, and loose files at the root.
+  function makeTree() {
+    const docs = folder('docs', [
+      file('readme.txt'),
+      file('presentation.ppt'),
+      file('report.pdf'),
+    ]);
+    const root = folder('root', [
+      docs,
+      folder('empty'),
+      file('logs.txt'),
+      file('landscape.png'),
+    ]);
+    return { root, docs };
+  }
+
+  describe('plain click', () => {
+    it('replaces the selection and sets the anchor', () => {
+      const { root } = makeTree();
+      const { ctx, state } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [, , logs, landscape] = root.children;
+
+      let activated = activate(strategy, logs, {}, new Set([landscape]));
+      expect(names(activated)).toEqual(['logs.txt']);
+      expect(toRaw(state.anchor)).toBe(logs);
+    });
+
+    it('opens a clicked folder', () => {
+      const { root, docs } = makeTree();
+      const { ctx, opened } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+
+      activate(strategy, docs, {});
+      expect(opened).toEqual(['docs']);
+    });
+  });
+
+  describe('ctrl/cmd click', () => {
+    it('toggles items in and out and moves the anchor', () => {
+      const { root } = makeTree();
+      const { ctx, state } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [, , logs, landscape] = root.children;
+
+      let activated = activate(strategy, logs, { ctrlKey: true });
+      activated = activate(strategy, landscape, { ctrlKey: true }, activated);
+      expect(names(activated)).toEqual(['logs.txt', 'landscape.png']);
+      expect(toRaw(state.anchor)).toBe(landscape);
+
+      activated = activate(strategy, logs, { ctrlKey: true }, activated);
+      expect(names(activated)).toEqual(['landscape.png']);
+    });
+
+    it('treats cmd (metaKey) like ctrl for macOS', () => {
+      const { root } = makeTree();
+      const { ctx } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [, , logs, landscape] = root.children;
+
+      let activated = activate(strategy, logs, { metaKey: true });
+      activated = activate(strategy, landscape, { metaKey: true }, activated);
+      expect(names(activated)).toEqual(['logs.txt', 'landscape.png']);
+    });
+  });
+
+  describe('shift click', () => {
+    it('selects the range between the anchor and the clicked item', () => {
+      const { root } = makeTree();
+      const { ctx } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [docs, , logs] = root.children;
+
+      let activated = activate(strategy, docs, {});
+      activated = activate(strategy, logs, { shiftKey: true }, activated);
+      expect(names(activated)).toEqual(['docs', 'empty', 'logs.txt']);
+    });
+
+    it('selects the range when clicking above the anchor', () => {
+      const { root } = makeTree();
+      const { ctx, state } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [docs, , logs] = root.children;
+
+      let activated = activate(strategy, logs, {});
+      activated = activate(strategy, docs, { shiftKey: true }, activated);
+      expect(names(activated)).toEqual(['docs', 'empty', 'logs.txt']);
+      // The anchor stays put so another shift click re-ranges from it
+      expect(toRaw(state.anchor)).toBe(logs);
+    });
+
+    it('anchors at the clicked item when there is no anchor yet', () => {
+      const { root } = makeTree();
+      const { ctx, state } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [, , logs, landscape] = root.children;
+
+      let activated = activate(strategy, logs, { shiftKey: true });
+      expect(names(activated)).toEqual(['logs.txt']);
+      expect(toRaw(state.anchor)).toBe(logs);
+
+      activated = activate(strategy, landscape, { shiftKey: true }, activated);
+      expect(names(activated)).toEqual(['logs.txt', 'landscape.png']);
+    });
+
+    it('ranges from the top of the folder when the anchor lives elsewhere', () => {
+      const { root, docs } = makeTree();
+      const { ctx } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const landscape = root.children[3];
+      const presentation = docs.children[1];
+
+      let activated = activate(strategy, landscape, {});
+      activated = activate(strategy, presentation, { shiftKey: true }, activated);
+      expect(names(activated)).toEqual(['readme.txt', 'presentation.ppt']);
+    });
+
+    it('resolves ranges when vuetify passes raw items but the tree is reactive', () => {
+      // This is the production condition: the consumer's rootDirectory is
+      // deep-reactive, while vuetify normalizes every id with toRaw. A plain
+      // indexOf across the two identities never matches and used to produce
+      // ranges anchored at -1 with undefined members.
+      const { root, docs } = makeTree();
+      const { ctx } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const rawReadme = toRaw(docs.children[0]);
+      const rawReport = toRaw(docs.children[2]);
+
+      let activated = activate(strategy, rawReadme, {});
+      activated = activate(strategy, rawReport, { shiftKey: true }, activated);
+
+      expect(names(activated)).toEqual([
+        'readme.txt',
+        'presentation.ppt',
+        'report.pdf',
+      ]);
+      for (const item of activated) {
+        expect(item).toBeDefined();
+        // Members must be raw so vuetify's own toRaw-based lookups match
+        expect(toRaw(item)).toBe(item);
+      }
+    });
+  });
+
+  describe('model sync (in/out)', () => {
+    it('in() keeps membership without side effects', () => {
+      const { root } = makeTree();
+      const { ctx, state, opened } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [docs, , logs] = root.children;
+
+      const set = (strategy as any).in([docs, logs], new Map(), new Map());
+      expect(names(set)).toEqual(['docs', 'logs.txt']);
+      expect(opened).toEqual([]);
+      expect(state.anchor).toBeNull();
+    });
+
+    it('out() returns the set as an array', () => {
+      const { root } = makeTree();
+      const { ctx } = makeContext(root);
+      const strategy = createFileExplorerActiveStrategy(ctx);
+      const [, , logs] = root.children;
+
+      expect((strategy as any).out(new Set([logs]))).toEqual([logs]);
+    });
+  });
+});

--- a/test/file-explorer-tree.test.ts
+++ b/test/file-explorer-tree.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { reactive, toRaw } from 'vue';
+import {
+  collectPaths,
+  resolveAcrossForests,
+} from '../src/components/cz.file-explorer.tree';
+import { IFile, IFolder } from '../src/types';
+
+let keyCounter = 0;
+
+function file(name: string): IFile {
+  return { name, key: keyCounter++, file: null, isUploaded: true };
+}
+
+function folder(name: string, children: (IFile | IFolder)[] = []): IFolder {
+  return { name, key: keyCounter++, children };
+}
+
+function makeForest() {
+  const deep = folder('deep', [file('deep file.txt')]);
+  const docs = folder('docs', [deep, file('readme.txt')]);
+  const empty = folder('empty');
+  return [docs, empty, file('logs.txt')] as (IFile | IFolder)[];
+}
+
+/** Clones a forest into all-new objects, as a server re-read produces. */
+function cloneForest(children: (IFile | IFolder)[]): (IFile | IFolder)[] {
+  return children.map(node => {
+    const copy: any = { name: node.name };
+    if (Object.prototype.hasOwnProperty.call(node, 'children')) {
+      copy.children = cloneForest((node as IFolder).children);
+    }
+    return copy;
+  });
+}
+
+describe('collectPaths', () => {
+  it('maps every node to its slash-joined path', () => {
+    const forest = makeForest();
+    const paths = [...collectPaths(forest).values()];
+    expect(paths).toEqual([
+      'docs',
+      'docs/deep',
+      'docs/deep/deep file.txt',
+      'docs/readme.txt',
+      'empty',
+      'logs.txt',
+    ]);
+  });
+
+  it('keys the map by raw objects even for a reactive forest', () => {
+    const forest = reactive({ children: makeForest() }).children;
+    const rawDocs = toRaw(forest[0]);
+    expect(collectPaths(forest).get(rawDocs)).toBe('docs');
+  });
+});
+
+describe('resolveAcrossForests', () => {
+  it('keeps items that still exist in the new forest', () => {
+    const forest = makeForest();
+    const logs = forest[2];
+    const resolved = resolveAcrossForests([logs], forest, forest);
+    expect(resolved).toEqual([logs]);
+  });
+
+  it('resolves items onto an all-new forest by path', () => {
+    const forest = makeForest();
+    const fresh = cloneForest(forest);
+    const docs = forest[0] as IFolder;
+    const deep = docs.children[0];
+
+    const resolved = resolveAcrossForests([docs, deep], forest, fresh);
+    expect(resolved.map(i => i.name)).toEqual(['docs', 'deep']);
+    expect(resolved[0]).toBe(fresh[0]);
+    expect(resolved[1]).toBe((fresh[0] as IFolder).children[0]);
+  });
+
+  it('drops items whose path no longer exists', () => {
+    const forest = makeForest();
+    const fresh = cloneForest(forest);
+    // The 'empty' folder was removed server-side after being emptied
+    fresh.splice(1, 1);
+    const empty = forest[1];
+    const docs = forest[0];
+
+    const resolved = resolveAcrossForests([docs, empty], forest, fresh);
+    expect(resolved.map(i => i.name)).toEqual(['docs']);
+  });
+
+  it('keeps the drop target open across a move refresh', () => {
+    const forest = makeForest();
+    const fresh = cloneForest(forest);
+    // logs.txt moved into 'empty', as the refreshed server read reports
+    const [logsClone] = fresh.splice(2, 1);
+    (fresh[1] as IFolder).children.push(logsClone);
+
+    // opened: the docs chain plus the drop target (old objects)
+    const docs = forest[0] as IFolder;
+    const opened = [docs, docs.children[0], forest[1]];
+    const resolved = resolveAcrossForests(opened, forest, fresh);
+    expect(resolved.map(i => i.name)).toEqual(['docs', 'deep', 'empty']);
+    expect(resolved[2]).toBe(fresh[1]);
+  });
+
+  it('resolves raw items against reactive forests', () => {
+    const oldForest = reactive({ children: makeForest() }).children;
+    const freshForest = reactive({
+      children: cloneForest(oldForest),
+    }).children;
+    const rawDocs = toRaw(oldForest[0]);
+
+    const resolved = resolveAcrossForests([rawDocs], oldForest, freshForest);
+    expect(resolved.map(i => i.name)).toEqual(['docs']);
+    expect(resolved[0]).toBe(toRaw(freshForest[0]));
+  });
+});


### PR DESCRIPTION
Fix multiple file selection with keyboard. A plain click selects one item, Ctrl/cmd click adds or removes individual items, and shift click selects everything between the last item you clicked and the current one. 

Folders now do not auto-collapse when moving files into them, or performing other operations on them.