### PR TITLE
6442: Support anyOf schema within an array

### DIFF
--- a/src/renderers/controls/ObjectControlRenderer.vue
+++ b/src/renderers/controls/ObjectControlRenderer.vue
@@ -86,20 +86,23 @@ export default defineComponent({
       nested,
     };
   },
-  // @deprecated: all of our renderers can now handle objects with undefined property values
-  // watch: {
-  //   "control.data": function (newVal, _oldVal) {
-  //     if (newVal) {
-  //       const filteredObj = Object.fromEntries(
-  //         Object.entries(newVal).filter(([_, value]) => value !== undefined) // strip out undefined properties
-  //       );
-
-  //       if (isEqual(filteredObj, {})) {
-  //         this.handleChange(this.control.path, undefined);
-  //       }
-  //     }
-  //   },
-  // },
+  watch: {
+    "control.data": {
+      handler(newVal: Record<string, unknown> | undefined) {
+        if (!this.isFlat || !newVal) return;
+        // Flat objects have no user-visible toggle, so clearing all sub-fields
+        // leaves a stub that fails required constraints. Remove the object
+        // entirely when no user-editable property has a value.
+        const hasMeaningfulValue = Object.entries(newVal)
+          .filter(([key]) => key !== '@type')
+          .some(([, v]) => v !== undefined && v !== null && v !== '');
+        if (!hasMeaningfulValue) {
+          this.handleChange(this.control.path, undefined);
+        }
+      },
+      deep: true,
+    },
+  },
   created() {
     // Seed required objects and non-flat ones without a toggle. Never seed an
     // optional object: the empty `{}` would fail its own `required` rules. It

--- a/src/renderers/layouts/ArrayLayoutRenderer.vue
+++ b/src/renderers/layouts/ArrayLayoutRenderer.vue
@@ -142,9 +142,24 @@
                 :class="styles.arrayList.itemContent"
                 class="pa-0"
               >
+                <v-select
+                  v-if="isCombinatorSchema(control.schema) && branchItems.length > 1"
+                  class="mb-4"
+                  :model-value="itemBranchIndex(element)"
+                  @update:model-value="(b) => handleBranchChange(index, b)"
+                  :items="branchItems"
+                  item-title="title"
+                  item-value="value"
+                  label="Type"
+                  :density="appliedOptions.vuetify?.commonAttrs?.density ?? 'compact'"
+                  :variant="appliedOptions.vuetify?.commonAttrs?.variant ?? 'outlined'"
+                  hide-details
+                  :disabled="!control.enabled || !!appliedOptions.isDisabled"
+                  :readonly="!control.enabled || !!appliedOptions.isViewMode || !!appliedOptions.isReadOnly"
+                />
                 <dispatch-renderer
                   :schema="itemSchema(element)"
-                  :uischema="foundUISchema"
+                  :uischema="itemUISchema(element)"
                   :path="composePaths(control.path, `${index}`)"
                   :enabled="control.enabled"
                   :renderers="control.renderers"
@@ -280,6 +295,7 @@ import {
   VExpansionPanelTitle,
   VExpansionPanelText,
   VChip,
+  VSelect,
 } from 'vuetify/components';
 import { ErrorObject } from 'ajv';
 import { ref, Ref } from 'vue';
@@ -311,6 +327,7 @@ export default defineComponent({
     VExpansionPanelText,
     VContainer,
     VChip,
+    VSelect,
     CzFieldset,
     ControlWrapper,
   },
@@ -361,6 +378,28 @@ export default defineComponent({
   computed: {
     noData(): boolean {
       return !this.control.data || this.control.data.length === 0;
+    },
+    /**
+     * Branch items for the inline type-switcher rendered for each array element
+     * when the items schema is a combinator (anyOf/oneOf/allOf).
+     * Labels are sourced from the nested detail map carried by the parent
+     * uischema option (`options.detail.options.detail[i].options.label`).
+     */
+    branchItems(): { title: string; value: number }[] {
+      const combinator = this.isCombinatorSchema(this.control.schema);
+      if (!combinator) return [];
+      // @ts-ignore
+      const branches: any[] = this.control.schema[combinator] || [];
+      // personOrOrgDetail lives at control.uischema.options.detail;
+      // per-branch layouts at .options.detail.options.detail
+      const detailMap = (this.control.uischema as any).options?.detail?.options?.detail;
+      return branches.map((_: any, idx: number) => ({
+        title:
+          detailMap?.[idx]?.options?.label ??
+          this.deref(branches[idx])?.title ??
+          `Type ${idx + 1}`,
+        value: idx,
+      }));
     },
     foundUISchema(): UISchemaElement {
       return findUISchema(
@@ -436,6 +475,60 @@ export default defineComponent({
   methods: {
     composePaths,
     createDefaultValue,
+    /**
+     * Return the combinator branch index that best fits `element`.
+     * Uses the `@type` discriminator; falls back to 0.
+     */
+    itemBranchIndex(element: any): number {
+      const combinator = this.isCombinatorSchema(this.control.schema);
+      if (!combinator) return 0;
+      // @ts-ignore
+      const branches: any[] = ((this.control.schema as any)[combinator] || []).map((b: any) => this.deref(b));
+      const discriminator = element?.['@type'];
+      if (!discriminator) return 0;
+      const idx = branches.findIndex((b: any) => {
+        const t = b?.properties?.['@type'];
+        return (
+          t &&
+          (t.const === discriminator ||
+            (Array.isArray(t.enum) && t.enum.includes(discriminator)))
+        );
+      });
+      return idx >= 0 ? idx : 0;
+    },
+    /**
+     * Return the uischema to use for a given array element.
+     * For combinator items, looks up the per-branch layout from the nested
+     * detail map (`options.detail.options.detail[branchIndex]`); falls back
+     * to `foundUISchema` for non-combinator arrays.
+     */
+    itemUISchema(element: any): UISchemaElement {
+      const combinator = this.isCombinatorSchema(this.control.schema);
+      if (!combinator) return this.foundUISchema;
+      const branchIndex = this.itemBranchIndex(element);
+      const detailMap = (this.control.uischema as any).options?.detail?.options?.detail;
+      if (detailMap != null && detailMap[branchIndex] != null) {
+        return detailMap[branchIndex];
+      }
+      return this.foundUISchema;
+    },
+    /**
+     * Switch an array item to a different combinator branch.
+     * Creates a fresh default value for the chosen branch (preserving the
+     * `@type` discriminator) and replaces the item at `itemIndex`.
+     */
+    handleBranchChange(itemIndex: number, newBranchIndex: number): void {
+      const combinator = this.isCombinatorSchema(this.control.schema);
+      if (!combinator || !this.control.enabled) return;
+      // @ts-ignore
+      const branches: any[] = (this.control.schema as any)[combinator] || [];
+      const defaultSchema = this.deref(branches[newBranchIndex]);
+      const newDefault = createDefaultValue(defaultSchema, this.control.rootSchema);
+      this.handleChange(
+        composePaths(this.control.path, `${itemIndex}`),
+        newDefault
+      );
+    },
     /**
      * Resolve a `$ref`, returning the original node when it can't be resolved.
      */

--- a/src/renderers/util/composition.ts
+++ b/src/renderers/util/composition.ts
@@ -343,7 +343,13 @@ export const useVuetifyArrayControl = <I extends { control: any }>(
   }
 
   const isChildEnabled = (index: number): boolean => {
-    return isEnabled(getChildUiSchema(), input.control.value.data, `${index}`, useAjv())
+    // getChildUiSchema() returns null when the items schema is a combinator
+    // (anyOf/oneOf/allOf) with no own properties — Generate.uiSchema returns
+    // null for a schema without properties. Guard here so isEnabled never
+    // receives null (which would crash on null.rule).
+    const uischema = getChildUiSchema();
+    if (!uischema) return true;
+    return isEnabled(uischema, input.control.value.data, `${index}`, useAjv(), input.control.value.config)
   }
 
   const childLabelForIndex = (index: number | null) => {

--- a/src/schemas/hydroshare/defaults.json
+++ b/src/schemas/hydroshare/defaults.json
@@ -10,6 +10,7 @@
   ],
   "creators": [
     {
+      "@type": "Person",
       "name": "Ramirez, Maurier",
       "phone": "+1 (435) 363-5910",
       "organization": "Utah State University",

--- a/src/schemas/hydroshare/schema.json
+++ b/src/schemas/hydroshare/schema.json
@@ -38,7 +38,10 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/definitions/Creator"
+        "anyOf": [
+          { "$ref": "#/definitions/CreatorPerson" },
+          { "$ref": "#/definitions/CreatorOrganization" }
+        ]
       }
     },
     "contributors": {
@@ -388,11 +391,11 @@
     "rights"
   ],
   "definitions": {
-    "Creator": {
-      "title": "Creator Metadata",
-      "description": "A class used to represent the metadata associated with a creator of a resource",
+    "CreatorPerson": {
+      "title": "Person",
       "type": "object",
       "properties": {
+        "@type": { "type": "string", "const": "Person", "default": "Person" },
         "name": {
           "title": "Name",
           "description": "A string containing the name of the creator",
@@ -445,9 +448,30 @@
           "$ref": "#/definitions/ProfileUrlPattern"
         }
       },
-      "required": [
-        "name"
-      ]
+      "required": ["name"]
+    },
+    "CreatorOrganization": {
+      "title": "Organization",
+      "type": "object",
+      "properties": {
+        "@type": { "type": "string", "const": "Organization", "default": "Organization" },
+        "name": {
+          "title": "Name",
+          "description": "A string containing the name of the organization",
+          "maxLength": 200,
+          "type": "string"
+        },
+        "email": {
+          "title": "Email",
+          "description": "A contact email address for the organization",
+          "type": "string",
+          "format": "email"
+        },
+        "homepage": {
+          "$ref": "#/definitions/UrlPattern"
+        }
+      },
+      "required": ["name"]
     },
     "Contributor": {
       "title": "Contributor Metadata",

--- a/src/schemas/hydroshare/uischema.json
+++ b/src/schemas/hydroshare/uischema.json
@@ -32,59 +32,62 @@
         ],
         "showSortButtons": true,
         "detail": {
-          "type": "VerticalLayout",
-          "elements": [
-            {
-              "type": "HorizontalLayout",
-              "elements": [
-                {
-                  "type": "Control",
-                  "scope": "#/properties/name"
-                },
-                {
-                  "type": "Control",
-                  "scope": "#/properties/email"
-                }
-              ]
-            },
-            {
-              "type": "HorizontalLayout",
-              "elements": [
-                {
-                  "type": "Control",
-                  "scope": "#/properties/organization"
-                },
-                {
-                  "type": "Control",
-                  "scope": "#/properties/address"
-                }
-              ]
-            },
-            {
-              "type": "HorizontalLayout",
-              "elements": [
-                {
-                  "type": "Control",
-                  "scope": "#/properties/phone"
-                },
-                {
-                  "type": "Control",
-                  "scope": "#/properties/homepage",
-                  "options": {
-                    "description": "URL for a website associated with the creator"
+          "options": {
+            "detail": {
+              "0": {
+                "type": "VerticalLayout",
+                "options": { "label": "Person" },
+                "elements": [
+                  {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                      { "type": "Control", "scope": "#/properties/name" },
+                      { "type": "Control", "scope": "#/properties/email" }
+                    ]
+                  },
+                  {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                      { "type": "Control", "scope": "#/properties/organization" },
+                      { "type": "Control", "scope": "#/properties/address" }
+                    ]
+                  },
+                  {
+                    "type": "HorizontalLayout",
+                    "elements": [
+                      { "type": "Control", "scope": "#/properties/phone" },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/homepage",
+                        "options": { "description": "URL for a website associated with the creator" }
+                      },
+                      {
+                        "type": "Control",
+                        "scope": "#/properties/profile_url",
+                        "options": {
+                          "placeholder": "e.g. 'https://www.hydroshare.org/user/10/'",
+                          "description": "A URL for the creator's HydroShare profile"
+                        }
+                      }
+                    ]
                   }
-                },
-                {
-                  "type": "Control",
-                  "scope": "#/properties/profile_url",
-                  "options": {
-                    "placeholder": "e.g. 'https://www.hydroshare.org/user/10/'",
-                    "description": "A URL for the creator's HydroShare profile"
+                ]
+              },
+              "1": {
+                "type": "VerticalLayout",
+                "options": { "label": "Organization" },
+                "elements": [
+                  { "type": "Control", "scope": "#/properties/name" },
+                  { "type": "Control", "scope": "#/properties/email" },
+                  {
+                    "type": "Control",
+                    "scope": "#/properties/homepage",
+                    "options": { "description": "URL for the organization's website" }
                   }
-                }
-              ]
+                ]
+              }
             }
-          ]
+          }
         }
       }
     },


### PR DESCRIPTION
Adds support for arrays whose items can be one of several types by letting ArrayLayoutRenderer handle that case: it inspects each item's @type field to determine which branch it belongs to, renders a dropdown so the user can switch branches, and routes the item to the correct schema and layout for that branch. 

Added to the Hydroshare schema used in the example app to demonstrate this functionality:

https://github.com/user-attachments/assets/37372a1d-7abb-4dff-b392-fe89d12b09a3

Pairs with https://github.com/hydroshare/hydroshare/pull/6464 for associated Hydroshare changes.

